### PR TITLE
Add code action for MI annotation

### DIFF
--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/mi/plugin/AnnotationAnalysisTask.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/mi/plugin/AnnotationAnalysisTask.java
@@ -46,8 +46,8 @@ import io.ballerina.tools.diagnostics.DiagnosticSeverity;
 import java.util.List;
 import java.util.Optional;
 
-import static io.ballerina.stdlib.mi.plugin.DiagnosticErrorCode.UNSUPPORTED_PARAM_TYPE;
-import static io.ballerina.stdlib.mi.plugin.DiagnosticErrorCode.UNSUPPORTED_RETURN_TYPE;
+import static io.ballerina.stdlib.mi.plugin.DiagnosticCode.UNSUPPORTED_PARAM_TYPE;
+import static io.ballerina.stdlib.mi.plugin.DiagnosticCode.UNSUPPORTED_RETURN_TYPE;
 
 public class AnnotationAnalysisTask implements AnalysisTask<SyntaxNodeAnalysisContext> {
 

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/mi/plugin/BalMediatorCodeAnalyzer.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/mi/plugin/BalMediatorCodeAnalyzer.java
@@ -40,5 +40,6 @@ public class BalMediatorCodeAnalyzer extends CodeAnalyzer {
                 List.of(SyntaxKind.SERVICE_DECLARATION, SyntaxKind.LISTENER_DECLARATION));
         codeAnalysisContext.addSyntaxNodeAnalysisTask(new VariableDeclarationAnalysisTask(),
                 List.of(SyntaxKind.MODULE_VAR_DECL, SyntaxKind.LOCAL_VAR_DECL));
+        codeAnalysisContext.addSyntaxNodeAnalysisTask(new FunctionAnalysisTask(), SyntaxKind.FUNCTION_DEFINITION);
     }
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/mi/plugin/DiagnosticCode.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/mi/plugin/DiagnosticCode.java
@@ -18,23 +18,31 @@
 
 package io.ballerina.stdlib.mi.plugin;
 
-public enum DiagnosticErrorCode {
-    UNSUPPORTED_PARAM_TYPE("MIE001", "unsupported parameter type found"),
-    UNSUPPORTED_RETURN_TYPE("MIE002", "unsupported return type found"),
+import io.ballerina.tools.diagnostics.DiagnosticSeverity;
+import static io.ballerina.tools.diagnostics.DiagnosticSeverity.ERROR;
+import static io.ballerina.tools.diagnostics.DiagnosticSeverity.INTERNAL;
+
+public enum DiagnosticCode {
+    UNSUPPORTED_PARAM_TYPE("MIE001", "unsupported parameter type found", ERROR),
+    UNSUPPORTED_RETURN_TYPE("MIE002", "unsupported return type found", ERROR),
     SERVICE_DEF_NOT_ALLOWED("MIE003",
-            "service definition is not allowed when `ballerinax/mi` connector is in use"),
+            "service definition is not allowed when `ballerinax/mi` connector is in use", ERROR),
     LISTENER_DECLARATION_NOT_ALLOWED("MIE004",
-            "listener declaration is not allowed when `ballerinax/mi` connector is in use"),
+            "listener declaration is not allowed when `ballerinax/mi` connector is in use", ERROR),
     LISTENER_SHAPE_VAR_NOT_ALLOWED("MIE005",
             "defining variables with a type that has the shape of `Listener` is not allowed when the `ballerinax/mi` " +
-                    "connector is in use.");
+                    "connector is in use.", ERROR),
+    MI_ANNOTATION_ADD("MI_HINT_001", "MI Annotation can be added", INTERNAL)
     ;
 
     private final String diagnosticId;
     private final String message;
-    DiagnosticErrorCode(String diagnosticId, String message) {
+    private final DiagnosticSeverity severity;
+
+    DiagnosticCode(String diagnosticId, String message, DiagnosticSeverity severity) {
         this.diagnosticId = diagnosticId;
         this.message = message;
+        this.severity = severity;
     }
 
     public String diagnosticId() {
@@ -42,5 +50,8 @@ public enum DiagnosticErrorCode {
     }
     public String message() {
         return message;
+    }
+    public DiagnosticSeverity severity() {
+        return severity;
     }
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/mi/plugin/FunctionAnalysisTask.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/mi/plugin/FunctionAnalysisTask.java
@@ -68,7 +68,7 @@ public class FunctionAnalysisTask implements AnalysisTask<SyntaxNodeAnalysisCont
                 continue;
             }
             Optional<ModuleSymbol> module = annotationSymbol.getModule();
-            if (module.isPresent() && module.get().getName().isPresent() && module.get().getName().get().equals("mi")) {
+            if (module.isPresent() && module.get().nameEquals("mi")) {
                 return true;
             }
         }
@@ -76,14 +76,7 @@ public class FunctionAnalysisTask implements AnalysisTask<SyntaxNodeAnalysisCont
     }
 
     private boolean checkFunctionParametersAndQualifiers(FunctionSymbol functionSymbol) {
-        boolean isPublic = false;
-        for (Qualifier qualifier : functionSymbol.qualifiers()) {
-            if (qualifier.name().equals(Qualifier.PUBLIC.name())) {
-                isPublic = true;
-                break;
-            }
-        }
-        if (!isPublic) {
+        if (functionSymbol.qualifiers().stream().noneMatch(q -> q == Qualifier.PUBLIC)) {
             return false;
         }
         Optional<List<ParameterSymbol>> params = functionSymbol.typeDescriptor().params();

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/mi/plugin/FunctionAnalysisTask.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/mi/plugin/FunctionAnalysisTask.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.mi.plugin;
+
+import io.ballerina.compiler.api.impl.symbols.BallerinaFunctionSymbol;
+import io.ballerina.compiler.api.symbols.AnnotationSymbol;
+import io.ballerina.compiler.api.symbols.FunctionSymbol;
+import io.ballerina.compiler.api.symbols.ModuleSymbol;
+import io.ballerina.compiler.api.symbols.ParameterSymbol;
+import io.ballerina.compiler.api.symbols.Qualifier;
+import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.projects.plugins.AnalysisTask;
+import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
+import io.ballerina.tools.diagnostics.DiagnosticFactory;
+import io.ballerina.tools.diagnostics.DiagnosticInfo;
+
+import java.util.List;
+import java.util.Optional;
+
+import static io.ballerina.stdlib.mi.plugin.MICompilerPluginUtils.getParamTypeName;
+import static io.ballerina.stdlib.mi.plugin.MICompilerPluginUtils.getReturnTypeName;
+
+public class FunctionAnalysisTask implements AnalysisTask<SyntaxNodeAnalysisContext> {
+
+    private final String ANNOTATION_NAME = "ConnectorInfo";
+
+    @Override
+    public void perform(SyntaxNodeAnalysisContext context) {
+        Node node = context.node();
+        Optional<Symbol> symbol = context.semanticModel().symbol(node);
+
+        if (symbol.isEmpty() || !(symbol.get() instanceof BallerinaFunctionSymbol functionSymbol) ||
+                !canAddMIAnnotation(functionSymbol)) {
+            return;
+        }
+        DiagnosticCode diagnosticCode = DiagnosticCode.MI_ANNOTATION_ADD;
+        context.reportDiagnostic(DiagnosticFactory.createDiagnostic(
+                new DiagnosticInfo(diagnosticCode.diagnosticId(), diagnosticCode.message(), diagnosticCode.severity()),
+                node.location()));
+    }
+
+    private boolean canAddMIAnnotation(BallerinaFunctionSymbol functionSymbol) {
+        return !hasMIAnnotation(functionSymbol) && checkFunctionParametersAndQualifiers(functionSymbol);
+    }
+
+    private boolean hasMIAnnotation(BallerinaFunctionSymbol functionSymbol) {
+        for (AnnotationSymbol annotationSymbol : functionSymbol.annotations()) {
+            Optional<String> name = annotationSymbol.getName();
+            if (name.isEmpty() || !name.get().equals(ANNOTATION_NAME)) {
+                continue;
+            }
+            Optional<ModuleSymbol> module = annotationSymbol.getModule();
+            if (module.isPresent() && module.get().getName().isPresent() && module.get().getName().get().equals("mi")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean checkFunctionParametersAndQualifiers(FunctionSymbol functionSymbol) {
+        boolean isPublic = false;
+        for (Qualifier qualifier : functionSymbol.qualifiers()) {
+            if (qualifier.name().equals(Qualifier.PUBLIC.name())) {
+                isPublic = true;
+                break;
+            }
+        }
+        if (!isPublic) {
+            return false;
+        }
+        Optional<List<ParameterSymbol>> params = functionSymbol.typeDescriptor().params();
+        if (params.isPresent()) {
+            for (ParameterSymbol parameterSymbol : params.get()) {
+                if (getParamTypeName(parameterSymbol.typeDescriptor().typeKind()) == null) {
+                    return false;
+                }
+            }
+        }
+        Optional<TypeSymbol> optReturnTypeSymbol = functionSymbol.typeDescriptor().returnTypeDescriptor();
+        return optReturnTypeSymbol.isEmpty() || getReturnTypeName(optReturnTypeSymbol.get().typeKind()) != null;
+    }
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/mi/plugin/ListenerAndServiceDefAnalysisTask.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/mi/plugin/ListenerAndServiceDefAnalysisTask.java
@@ -35,12 +35,12 @@ public class ListenerAndServiceDefAnalysisTask implements AnalysisTask<SyntaxNod
 
     @Override
     public void perform(SyntaxNodeAnalysisContext context) {
-        DiagnosticErrorCode diagnosticCode;
+        DiagnosticCode diagnosticCode;
         Node node = context.node();
         if (node.kind() == SyntaxKind.SERVICE_DECLARATION) {
-            diagnosticCode = DiagnosticErrorCode.SERVICE_DEF_NOT_ALLOWED;
+            diagnosticCode = DiagnosticCode.SERVICE_DEF_NOT_ALLOWED;
         } else {
-            diagnosticCode = DiagnosticErrorCode.LISTENER_DECLARATION_NOT_ALLOWED;
+            diagnosticCode = DiagnosticCode.LISTENER_DECLARATION_NOT_ALLOWED;
         }
         DiagnosticInfo diagnosticInfo =
                 new DiagnosticInfo(diagnosticCode.diagnosticId(), diagnosticCode.message(), DiagnosticSeverity.ERROR);

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/mi/plugin/MICompilerPlugin.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/mi/plugin/MICompilerPlugin.java
@@ -20,6 +20,10 @@ package io.ballerina.stdlib.mi.plugin;
 
 import io.ballerina.projects.plugins.CompilerPlugin;
 import io.ballerina.projects.plugins.CompilerPluginContext;
+import io.ballerina.projects.plugins.codeaction.CodeAction;
+import io.ballerina.stdlib.mi.plugin.codeaction.MIAnnotationCodeAction;
+
+import java.util.List;
 
 public class MICompilerPlugin extends CompilerPlugin {
 
@@ -27,6 +31,13 @@ public class MICompilerPlugin extends CompilerPlugin {
     public void init(CompilerPluginContext compilerPluginContext) {
         compilerPluginContext.addCodeAnalyzer(new BalMediatorCodeAnalyzer());
         compilerPluginContext.addCompilerLifecycleListener(new BalLifecycleListener());
+        getCodeActions().forEach(compilerPluginContext::addCodeAction);
+    }
+
+    private List<CodeAction> getCodeActions() {
+        return List.of(
+                new MIAnnotationCodeAction()
+        );
     }
 }
 

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/mi/plugin/MICompilerPluginUtils.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/mi/plugin/MICompilerPluginUtils.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.mi.plugin;
+
+import io.ballerina.compiler.api.symbols.TypeDescKind;
+
+public class MICompilerPluginUtils {
+
+    public static String getParamTypeName(TypeDescKind typeKind) {
+        return switch (typeKind) {
+            case BOOLEAN, INT, STRING, FLOAT, DECIMAL, XML, JSON -> typeKind.getName();
+            default -> null;
+        };
+    }
+
+    public static String getReturnTypeName(TypeDescKind typeKind) {
+        return switch (typeKind) {
+            case NIL, BOOLEAN, INT, STRING, FLOAT, DECIMAL, XML, JSON, ANY -> typeKind.getName();
+            default -> null;
+        };
+    }
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/mi/plugin/VariableDeclarationAnalysisTask.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/mi/plugin/VariableDeclarationAnalysisTask.java
@@ -69,7 +69,7 @@ public class VariableDeclarationAnalysisTask implements AnalysisTask<SyntaxNodeA
             if (!classMethods.containsAll(methods)) {
                 continue;
             }
-            DiagnosticErrorCode diagnosticCode = DiagnosticErrorCode.LISTENER_SHAPE_VAR_NOT_ALLOWED;
+            DiagnosticCode diagnosticCode = DiagnosticCode.LISTENER_SHAPE_VAR_NOT_ALLOWED;
             DiagnosticInfo diagnosticInfo =
                     new DiagnosticInfo(diagnosticCode.diagnosticId(), diagnosticCode.message(),
                             DiagnosticSeverity.ERROR);

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/mi/plugin/codeaction/MIAnnotationCodeAction.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/mi/plugin/codeaction/MIAnnotationCodeAction.java
@@ -1,0 +1,125 @@
+/*
+ *
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ *  *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *  *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package io.ballerina.stdlib.mi.plugin.codeaction;
+
+import io.ballerina.compiler.syntax.tree.FunctionDefinitionNode;
+import io.ballerina.compiler.syntax.tree.ModulePartNode;
+import io.ballerina.compiler.syntax.tree.NonTerminalNode;
+import io.ballerina.compiler.syntax.tree.SyntaxKind;
+import io.ballerina.compiler.syntax.tree.SyntaxTree;
+import io.ballerina.projects.plugins.codeaction.CodeActionArgument;
+import io.ballerina.projects.plugins.codeaction.CodeActionContext;
+import io.ballerina.projects.plugins.codeaction.CodeActionExecutionContext;
+import io.ballerina.projects.plugins.codeaction.CodeActionInfo;
+import io.ballerina.projects.plugins.codeaction.DocumentEdit;
+import io.ballerina.stdlib.mi.plugin.DiagnosticCode;
+import io.ballerina.tools.text.LineRange;
+import io.ballerina.tools.text.TextDocument;
+import io.ballerina.tools.text.TextDocumentChange;
+import io.ballerina.tools.text.TextEdit;
+import io.ballerina.tools.text.TextRange;
+import io.ballerina.projects.plugins.codeaction.CodeAction;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Code action that adds the MI annotation to a ballerina function.
+ *
+ * @since 0.1.4
+ */
+public class MIAnnotationCodeAction implements CodeAction {
+
+    private final String NAME = "Add MI annotation";
+    private final String NODE_LOCATION_KEY = "node.location";
+    private final String ANNOTATION_STRING = "@mi:ConnectorInfo\n";
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public List<String> supportedDiagnosticCodes() {
+        return List.of(DiagnosticCode.MI_ANNOTATION_ADD.diagnosticId());
+    }
+
+    @Override
+    public Optional<CodeActionInfo> codeActionInfo(CodeActionContext context) {
+        NonTerminalNode node =
+                findNode(context.currentDocument().syntaxTree(), context.diagnostic().location().lineRange());
+        if (node == null || node.kind() != SyntaxKind.FUNCTION_DEFINITION) {
+            return Optional.empty();
+        }
+
+        CodeActionArgument locationArg = CodeActionArgument.from(NODE_LOCATION_KEY, node.location().lineRange());
+        return Optional.of(CodeActionInfo.from(NAME, List.of(locationArg)));
+
+    }
+
+    @Override
+    public List<DocumentEdit> execute(CodeActionExecutionContext context) {
+        Optional<LineRange> lineRange = getLineRangeFromLocationKey(context);
+
+        if (lineRange.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        SyntaxTree syntaxTree = context.currentDocument().syntaxTree();
+        NonTerminalNode node = findNode(syntaxTree, lineRange.get());
+
+        int start = getFunctionStartOffset((FunctionDefinitionNode) node);
+        TextRange textRange = TextRange.from(start, 0);
+        List<TextEdit> textEdits = List.of(TextEdit.from(textRange, ANNOTATION_STRING));
+        TextDocumentChange change = TextDocumentChange.from(textEdits.toArray(new TextEdit[0]));
+        TextDocument modifiedTextDocument = syntaxTree.textDocument().apply(change);
+        return Collections.singletonList(new DocumentEdit(context.fileUri(), SyntaxTree.from(modifiedTextDocument)));
+    }
+
+    private NonTerminalNode findNode(SyntaxTree syntaxTree, LineRange lineRange) {
+        if (lineRange == null) {
+            return null;
+        }
+
+        TextDocument textDocument = syntaxTree.textDocument();
+        int start = textDocument.textPositionFrom(lineRange.startLine());
+        int end = textDocument.textPositionFrom(lineRange.endLine());
+        return ((ModulePartNode) syntaxTree.rootNode()).findNode(TextRange.from(start, end - start), true);
+    }
+
+    private Optional<LineRange> getLineRangeFromLocationKey(CodeActionExecutionContext context) {
+        for (CodeActionArgument argument : context.arguments()) {
+            if (NODE_LOCATION_KEY.equals(argument.key())) {
+                return Optional.of(argument.valueAs(LineRange.class));
+            }
+        }
+        return Optional.empty();
+    }
+
+    private int getFunctionStartOffset(FunctionDefinitionNode node) {
+        if (node.qualifierList().size() > 0) {
+            return node.qualifierList().get(0).textRange().startOffset();
+        }
+        return node.functionKeyword().textRange().startOffset();
+    }
+
+}

--- a/tests/src/test/java/org/ballerina/test/AnnotationTest.java
+++ b/tests/src/test/java/org/ballerina/test/AnnotationTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerina.test;
+
+import com.google.gson.Gson;
+import io.ballerina.projects.CodeActionManager;
+import io.ballerina.projects.Document;
+import io.ballerina.projects.DocumentId;
+import io.ballerina.projects.Package;
+import io.ballerina.projects.PackageCompilation;
+import io.ballerina.projects.Project;
+import io.ballerina.projects.ProjectEnvironmentBuilder;
+import io.ballerina.projects.directory.ProjectLoader;
+import io.ballerina.projects.environment.EnvironmentBuilder;
+import io.ballerina.projects.plugins.codeaction.CodeActionArgument;
+import io.ballerina.projects.plugins.codeaction.CodeActionContextImpl;
+import io.ballerina.projects.plugins.codeaction.CodeActionExecutionContext;
+import io.ballerina.projects.plugins.codeaction.CodeActionExecutionContextImpl;
+import io.ballerina.projects.plugins.codeaction.CodeActionInfo;
+import io.ballerina.projects.plugins.codeaction.DocumentEdit;
+import io.ballerina.tools.text.LinePosition;
+import io.ballerina.tools.text.LineRange;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class AnnotationTest {
+
+    private final Gson GSON = new Gson();
+    private final Path RESOURCE_PATH = Paths.get("src", "test", "resources", "ballerina", "annotation_code_action");
+    private final String PROVIDER_NAME = "MI_HINT_001/ballerinax/mi/Add MI annotation";
+    private Project project;
+    private Path filePath;
+    private Project projectNeg;
+    private Path filePathNeg;
+
+    @BeforeClass
+    public void setup() {
+        filePath = RESOURCE_PATH.resolve("add_mi.bal");
+        filePathNeg = RESOURCE_PATH.resolve("add_mi_neg.bal");
+        project = ProjectLoader.loadProject(filePath,
+                ProjectEnvironmentBuilder.getBuilder(EnvironmentBuilder.getBuilder().build()));
+        projectNeg = ProjectLoader.loadProject(filePathNeg,
+                ProjectEnvironmentBuilder.getBuilder(EnvironmentBuilder.getBuilder().build()));
+    }
+
+    @Test(dataProvider = "testMIAnnotationDataProvider")
+    public void testMIAnnotationAddCodeAction(LinePosition linePosition) {
+        Package currentPackage = project.currentPackage();
+        PackageCompilation compilation = currentPackage.getCompilation();
+        CodeActionManager codeActionManager = compilation.getCodeActionManager();
+
+        List<CodeActionInfo> codeActions =
+                getCodeActions(filePath, linePosition, project, currentPackage, compilation, codeActionManager);
+        Optional<CodeActionInfo> found = getMIAnnotationCodeActionInfo(codeActions);
+        Assert.assertTrue(found.isPresent(), "Codeaction not found for line position: " + linePosition);
+        Assert.assertEquals(executeCodeAction(project, filePath, found.get(), currentPackage, compilation).size(), 1,
+                "Expected a change to the file");
+    }
+
+    @DataProvider(name = "testMIAnnotationDataProvider")
+    public Object[] testMIAnnotationDataProvider() {
+        return new Object[]{
+                LinePosition.from(18, 0), LinePosition.from(22, 0), LinePosition.from(26, 0)
+        };
+    }
+
+    @Test(dataProvider = "testMIAnnotationNegativeDataProvider")
+    public void testMIAnnotationAddCodeActionNegative(LinePosition linePosition) {
+        Package currentPackage = projectNeg.currentPackage();
+        PackageCompilation compilation = currentPackage.getCompilation();
+        CodeActionManager codeActionManager = compilation.getCodeActionManager();
+
+        List<CodeActionInfo> codeActions =
+                getCodeActions(filePathNeg, linePosition, projectNeg, currentPackage, compilation, codeActionManager);
+        Assert.assertEquals(codeActions.size(), 0, "Did not expect MI Annotation code action at: " + linePosition);
+    }
+
+    @DataProvider(name = "testMIAnnotationNegativeDataProvider")
+    public Object[] testMIAnnotationNegativeDataProvider() {
+        return new Object[]{
+                LinePosition.from(24, 0), LinePosition.from(28, 0), LinePosition.from(16, 0),
+                LinePosition.from(32, 0), LinePosition.from(36, 0), LinePosition.from(40, 0),
+                LinePosition.from(44, 0), LinePosition.from(48, 0)
+        };
+    }
+
+    private Optional<CodeActionInfo> getMIAnnotationCodeActionInfo(List<CodeActionInfo> codeActions) {
+        return codeActions.stream()
+                .filter(codeActionInfo -> codeActionInfo.getProviderName().equals(PROVIDER_NAME))
+                .findFirst();
+    }
+
+    private List<CodeActionInfo> getCodeActions(Path filePath, LinePosition cursorPos, Project project,
+                                                Package currentPackage, PackageCompilation compilation,
+                                                CodeActionManager codeActionManager) {
+        DocumentId documentId = project.documentId(filePath);
+        Document document = currentPackage.getDefaultModule().document(documentId);
+
+        return compilation.diagnosticResult().diagnostics().stream()
+                .filter(diagnostic -> isWithinRange(diagnostic.location().lineRange(), cursorPos) &&
+                        filePath.endsWith(diagnostic.location().lineRange().filePath()))
+                .flatMap(diagnostic -> {
+                    CodeActionContextImpl context = CodeActionContextImpl.from(
+                            filePath.toUri().toString(), filePath, cursorPos, document,
+                            compilation.getSemanticModel(documentId.moduleId()), diagnostic);
+                    return codeActionManager.codeActions(context).getCodeActions().stream();
+                })
+                .collect(Collectors.toList());
+    }
+
+    private List<DocumentEdit> executeCodeAction(Project project, Path filePath, CodeActionInfo codeAction,
+                                                 Package currentPackage, PackageCompilation compilation) {
+        DocumentId documentId = project.documentId(filePath);
+        Document document = currentPackage.getDefaultModule().document(documentId);
+
+        List<CodeActionArgument> codeActionArguments = codeAction.getArguments().stream()
+                .map(arg -> CodeActionArgument.from(GSON.toJsonTree(arg)))
+                .collect(Collectors.toList());
+
+        CodeActionExecutionContext executionContext = CodeActionExecutionContextImpl.from(
+                filePath.toUri().toString(),
+                filePath,
+                null,
+                document,
+                compilation.getSemanticModel(document.documentId().moduleId()),
+                codeActionArguments);
+
+        return compilation.getCodeActionManager()
+                .executeCodeAction(codeAction.getProviderName(), executionContext);
+    }
+
+    private static boolean isWithinRange(LineRange lineRange, LinePosition pos) {
+        int sLine = lineRange.startLine().line();
+        int sCol = lineRange.startLine().offset();
+        int eLine = lineRange.endLine().line();
+        int eCol = lineRange.endLine().offset();
+
+        return ((sLine == eLine && pos.line() == sLine) &&
+                (pos.offset() >= sCol && pos.offset() <= eCol)
+        ) || ((sLine != eLine) && (pos.line() > sLine && pos.line() < eLine ||
+                pos.line() == eLine && pos.offset() <= eCol ||
+                pos.line() == sLine && pos.offset() >= sCol
+        ));
+    }
+}

--- a/tests/src/test/resources/ballerina/annotation_code_action/Ballerina.toml
+++ b/tests/src/test/resources/ballerina/annotation_code_action/Ballerina.toml
@@ -1,0 +1,14 @@
+[package]
+org = "testOrg"
+name = "annotation_code_action"
+version = "0.1.0"
+distribution = "2201.9.2"
+
+[build-options]
+observabilityIncluded = true
+
+[[dependency]]
+org = "ballerinax"
+name = "mi"
+version = "0.1.3"
+repository = "local"

--- a/tests/src/test/resources/ballerina/annotation_code_action/add_mi.bal
+++ b/tests/src/test/resources/ballerina/annotation_code_action/add_mi.bal
@@ -1,0 +1,34 @@
+// Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerinax/mi;
+
+public function f1(xml b, boolean c, json w) {
+
+}
+
+public function f2() {
+
+}
+
+public function f8(int a) returns xml {
+    return xml ``;
+}
+
+@mi:ConnectorInfo
+public function f12(int a) returns xml {
+    return xml ``;
+}

--- a/tests/src/test/resources/ballerina/annotation_code_action/add_mi_neg.bal
+++ b/tests/src/test/resources/ballerina/annotation_code_action/add_mi_neg.bal
@@ -1,0 +1,55 @@
+// Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerinax/mi;
+
+public type Rec record {|
+    string a;
+    int b;
+|};
+
+@mi:ConnectorInfo
+public function f3(int a) {
+
+}
+
+function f4() {
+
+}
+
+public function f5(Rec rec) {
+
+}
+
+public function f6(int a) returns Rec {
+    return {a: "a", b: 1};
+}
+
+public function f7(int|string a) {
+
+}
+
+public function f9(error e) {
+
+}
+
+public function f10() returns error? {
+
+}
+
+public function f11(int? a) {
+
+}


### PR DESCRIPTION
## Purpose
$subject

Add a code action to add the `@mi:CodeInfo` annotation for functions which can have that annotation.

The functions that can have this annotations are the,
1. The functions that already does not have this validation
2. Function should be public 
3. Function whose parameters and the return types are boolean, int, string, json and xml.