### PR TITLE
Add command to generate a template ballerina file

### DIFF
--- a/tool/tool-mi-cli/build.gradle
+++ b/tool/tool-mi-cli/build.gradle
@@ -16,6 +16,8 @@
  * under the License.
  */
 
+import org.apache.tools.ant.taskdefs.condition.Os
+
 plugins {
     id 'java'
 }
@@ -50,4 +52,56 @@ dependencies {
     implementation 'info.picocli:picocli:4.0.1'
     implementation "org.ballerinalang:ballerina-lang:${ballerinaLangVersion}"
     implementation "org.ballerinalang:ballerina-tools-api:${ballerinaLangVersion}"
+
+    testImplementation 'org.testng:testng:7.7.0'
+}
+
+test {
+    systemProperty "ballerina.home", "build/ballerina/ballerina-${ballerinaLangVersion}-swan-lake/" +
+            "distributions/ballerina-${ballerinaLangVersion}"
+    useTestNG() {
+        suites 'src/test/resources/testng.xml'
+    }
+    dependencies {
+        implementation fileTree(dir: 'src/test/resources/libs', include: '*.jar')
+    }
+}
+
+task downloadBallerina(type: Download) {
+    src([
+            "https://dist.ballerina.io/downloads/${ballerinaLangVersion}/" +
+                    "ballerina-${ballerinaLangVersion}-swan-lake.zip"
+    ])
+    dest file("build")
+    overwrite false
+}
+
+task unzipFile(type: Copy) {
+    dependsOn("downloadBallerina")
+    from(zipTree("build/ballerina-${ballerinaLangVersion}-swan-lake.zip"))
+    into("build/ballerina")
+}
+
+task copyBallerinaJars(type: Copy) {
+    dependsOn("buildBallerinaProject")
+    projects.each { project ->
+        from("src/test/resources/ballerina/${project}/target/bin/${project}.jar")
+        into('src/test/resources/libs')
+    }
+}
+compileTestJava.dependsOn("copyBallerinaJars")
+processTestResources.dependsOn("copyBallerinaJars")
+
+test.dependsOn(":mi-ballerina:localPublish")
+test.dependsOn("unzipFile")
+test.dependsOn("copyBallerinaJars")
+
+task buildBallerinaProject {
+    exec {
+        if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+            commandLine 'cmd', "/c", "bal build src/test/resources/ballerina/gen"
+        } else {
+            commandLine 'sh', "-c", "bal build src/test/resources/ballerina/gen"
+        }
+    }
 }

--- a/tool/tool-mi-cli/src/main/resources/cli-docs/mi.help
+++ b/tool/tool-mi-cli/src/main/resources/cli-docs/mi.help
@@ -11,6 +11,12 @@ OPTIONS
        -i, --input <ballerina project>
            Path to Ballerina project that includes the transformation logic.
 
+       -g, --generate-template <file-name>
+           Generate a Ballerina file with mi module imported and a template function.
+
 EXAMPLES
        Generate WSO2 micro integrator connector for Ballerina.
            $ bal mi -i ballerina/project
+
+       Generate a template Ballerina file.
+           $ bal mi -g gen.bal

--- a/tool/tool-mi-cli/src/main/resources/generate_cmd_templates/generate.bal
+++ b/tool/tool-mi-cli/src/main/resources/generate_cmd_templates/generate.bal
@@ -1,0 +1,7 @@
+import ballerinax/mi;
+
+@mi:ConnectorInfo
+public function transform(xml inputData) returns xml {
+    // Add your implementation logic here
+    return inputData;
+}

--- a/tool/tool-mi-cli/src/test/java/io/ballerina/mi/cmd/test/GenerateOptionTest.java
+++ b/tool/tool-mi-cli/src/test/java/io/ballerina/mi/cmd/test/GenerateOptionTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.mi.cmd.test;
+
+import io.ballerina.mi.cmd.MiCmd;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
+import picocli.CommandLine;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static io.ballerina.projects.util.ProjectConstants.USER_DIR;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class GenerateOptionTest {
+
+    private final Path BASE_PATH = Paths.get("src", "test", "resources", "ballerina");
+    private final Path PACKAGE_PATH = BASE_PATH.resolve("gen");
+    private final ByteArrayOutputStream outputErrStream = new ByteArrayOutputStream();
+
+    @BeforeTest
+    public void setup() {
+        System.setErr(new PrintStream(outputErrStream));
+    }
+
+    @Test
+    public void testGenerateCommand() {
+        System.setProperty(USER_DIR, PACKAGE_PATH.toAbsolutePath().toString());
+        String[] args = {"-g", "gen.bal"};
+        MiCmd miCmd = new MiCmd();
+        new CommandLine(miCmd).parseArgs(args);
+        miCmd.execute();
+        Assert.assertTrue(Files.exists(PACKAGE_PATH.resolve("gen.bal")));
+    }
+
+    @Test
+    public void testGenerateCommandWithExistingFileName() {
+        System.setProperty(USER_DIR, PACKAGE_PATH.toAbsolutePath().toString());
+        String[] args = {"-g", "main.bal"};
+        MiCmd miCmd = new MiCmd();
+        new CommandLine(miCmd).parseArgs(args);
+        miCmd.execute();
+        Assert.assertTrue(outputErrStream.toString()
+                .contains("A file with the specified name already exists in the Ballerina Project"));
+    }
+
+    @Test
+    public void testGenerateCommandWithNonBallerinaProject() {
+        System.setProperty(USER_DIR, BASE_PATH.toAbsolutePath().toString());
+        String[] args = {"-g", "main.bal"};
+        MiCmd miCmd = new MiCmd();
+        new CommandLine(miCmd).parseArgs(args);
+        miCmd.execute();
+        Assert.assertTrue(outputErrStream.toString().contains("Current directory is not a Ballerina Project"));
+    }
+
+    @AfterTest
+    public void clean() throws IOException {
+        Files.deleteIfExists(PACKAGE_PATH.resolve("gen.bal"));
+    }
+
+}

--- a/tool/tool-mi-cli/src/test/resources/ballerina/gen/Ballerina.toml
+++ b/tool/tool-mi-cli/src/test/resources/ballerina/gen/Ballerina.toml
@@ -1,0 +1,14 @@
+[package]
+org = "testOrg"
+name = "gen"
+version = "0.1.0"
+distribution = "2201.9.2"
+
+[build-options]
+observabilityIncluded = true
+
+[[dependency]]
+org = "ballerinax"
+name = "mi"
+version = "0.1.3"
+repository = "local"

--- a/tool/tool-mi-cli/src/test/resources/ballerina/gen/main.bal
+++ b/tool/tool-mi-cli/src/test/resources/ballerina/gen/main.bal
@@ -1,0 +1,20 @@
+// Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+public function main() {
+    int a = 2;
+    _ = a;
+}

--- a/tool/tool-mi-cli/src/test/resources/testng.xml
+++ b/tool/tool-mi-cli/src/test/resources/testng.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2024, WSO2 LLC. (http://wso2.com).
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd" >
+
+<suite name="ballerina-tool-mi-cli-test-suite" time-out="120000">
+    <test name="tool-mi-cli">
+        <packages>
+            <package name="io.ballerina.mi.cmd.test.*"/>
+        </packages>
+    </test>
+</suite>


### PR DESCRIPTION
## Purpose

Add a command to generate a template ballerina file with the mi module imported and a template ballerina function.
This can be done with the following command.
`bal mi -g file.bal` or `bal mi -generate-template file.bal`