### PR TITLE
[Temp] Remove Sync PR after release

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -54,4 +54,3 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
         run: |
           gh release create v$VERSION --title "mi-tools-v$VERSION"
-          gh pr create --base main --title "[Automated] Sync main after $VERSION release" --body "Sync main after $VERSION release"


### PR DESCRIPTION
## Purpose

This is done temporary  because Git Token doesn't have enough permissions.
