### PR TITLE
Enhance type handling in MICompilerPluginUtils to support RECORD, MAP and ARRAY types in parameter and return type name methods

### DIFF
--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/mi/plugin/MICompilerPluginUtils.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/mi/plugin/MICompilerPluginUtils.java
@@ -24,14 +24,14 @@ public class MICompilerPluginUtils {
 
     public static String getParamTypeName(TypeDescKind typeKind) {
         return switch (typeKind) {
-            case BOOLEAN, INT, STRING, FLOAT, DECIMAL, XML, JSON -> typeKind.getName();
+            case BOOLEAN, INT, STRING, FLOAT, DECIMAL, XML, JSON, RECORD, MAP, ARRAY -> typeKind.getName();
             default -> null;
         };
     }
 
     public static String getReturnTypeName(TypeDescKind typeKind) {
         return switch (typeKind) {
-            case NIL, BOOLEAN, INT, STRING, FLOAT, DECIMAL, XML, JSON, ANY -> typeKind.getName();
+            case NIL, BOOLEAN, INT, STRING, FLOAT, DECIMAL, XML, JSON, ANY, RECORD, MAP, ARRAY -> typeKind.getName();
             default -> null;
         };
     }


### PR DESCRIPTION
## Purpose

> This pull request resolves the need to support `record` and `map<anydata>` types within the Ballerina to WSO2 Micro Integrator (MI) module generation process. Currently, the compiler plugin imposes limitations that prevent the use of these complex types in functions annotated with `@mi:Operation`. This feature is essential for handling more complex data structures when creating MI artifacts.
>
> Resolves: https://github.com/wso2/product-micro-integrator/issues/4513

## Goals

> The primary goal of this PR is to update the compiler plugin to allow developers to use `record` and `map<anydata>` types in their Ballerina functions. This is the first step in enabling the `ballerina-mi-module-gen-tool` to correctly generate the corresponding MI artifacts.

## Approach

> To achieve the desired functionality, I have implemented the following changes:
>
>1.  **Updated the Compiler Plugin:** I have modified the `MICompilerPluginUtils.java` file in the `ballerina-module-wso2-mi` project to include `RECORD`, `MAP`, and `ARRAY` in the list of supported types for both function parameters and return values. This ensures that the compiler no longer flags these types as unsupported when used in functions annotated with `@mi:Operation`.

## User stories

> As a developer, I want to use `record` and `map<anydata>` types in my Ballerina functions and generate MI artifacts from them, so that I can handle complex data structures without being restricted to primitive types.

## Release note

> This release adds support for `record` and `map<anydata>` types in the Ballerina to MI module generation process, allowing for the use of more complex data structures in MI artifacts.

## Documentation

> N/A. This change enhances the functionality of the MI module generation tool to support additional Ballerina types and does not introduce any new user-facing features that would require documentation changes.

## Training

> N/A

## Certification

> N/A. This change is an enhancement to the existing functionality and does not impact the core concepts or features covered in the certification exams.

## Marketing

> N/A

## Automation tests

- Unit tests
  > The project was successfully built after the changes were implemented, ensuring that the modifications are syntactically correct and do not break the existing build process.
- Integration tests
  > No new integration tests were added as part of this change.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? yes
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

> N/A

## Related PRs

> This PR contains the compiler plugin changes required to support `record` and `map<anydata>` types. The corresponding changes in the `ballerina-mi-module-gen-tool` will be handled in a separate pull request.

## Migrations (if applicable)

> N/A

## Test environment

> - **JDK Version:** 21
> - **Operating System:** MacOS 

## Learning

> The implementation was guided by the investigation of the `ballerina-module-wso2-mi` project, as well as the information provided in the related issue: https://github.com/wso2/product-micro-integrator/issues/4513. The analysis revealed that the compiler plugin needed to be updated to support the new types.